### PR TITLE
[ci skip] adding user @rjgildea

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @anthchirp
+* @rjgildea @anthchirp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,4 +36,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - rjgildea
     - anthchirp


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @rjgildea as instructed in #9.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #9